### PR TITLE
v0.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
   name: "LintLokalization",
+  platforms: [
+    .macOS(.v12),
+  ],
   products: [
     .library(
       name: "Lib",

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ XCode will automatically display warnings for all unknown localization keys.
 Instead of warnings, you can configure `LintLokalize` to output errors. Severity is controlled by the `--severity` option:
 
 ```bash
-MyProject/ ~ LintLokalize Resources/Localization/en.lproj/Localizable.string --severity error
+MyProject/ ~ LintLokalize Resources/Localization/en.lproj/Localizable.strings --severity error
 1. Processing:  MyProject/File1.swift
 2. Processing:  MyProject/File2.swift
 3. Processing:  MyProject/File3.swift
@@ -100,7 +100,7 @@ When doing so, XCode will mark the build as failed if any localization is unreso
 
 
 ```bash
-MyProject/ ~ LintLokalize Resources/Localization/en.lproj/Localizable.string --reported cmd
+MyProject/ ~ LintLokalize Resources/Localization/en.lproj/Localizable.string --reporter cmh
 1. Processing:  MyProject/File1.swift
 2. Processing:  MyProject/File2.swift
 3. Processing:  MyProject/File3.swift

--- a/Sources/Lib/LintLokalization.swift
+++ b/Sources/Lib/LintLokalization.swift
@@ -19,7 +19,7 @@ public struct Main: ParsableCommand {
   var realtime: Bool = false // @TODO: - Not yet used
   
   @Option(help: "Number of working threads.")
-  var threads: Int = 1
+  var threads: Int = 8
   
   public init() {}
   
@@ -29,7 +29,6 @@ public struct Main: ParsableCommand {
     let (time1, contents) = try benchmark { () -> Set<String> in
       let fileManager = FileManager.default
       let workingDirectory = fileManager.currentDirectoryPath
-//      let workingDirectory = "/Users/tony/swift/XcodeBenchmark"
       let contents = try loadContentsOfADirectory(
         path: workingDirectory,
         fileManager: fileManager)

--- a/Sources/Lib/LintLokalization.swift
+++ b/Sources/Lib/LintLokalization.swift
@@ -123,7 +123,9 @@ public struct Main: ParsableCommand {
       print("❗️ Found \(output.errorCount) unresolved localizations!".bold.red)
     }
     
-    guard benchmarkMode else { return }
+    guard benchmarkMode else {
+      Foundation.exit(Int32(output.errorCount))
+    }
     print(
       [
         "Executed in: \(time1 + time2 + time3)s".lightBlue.italic,

--- a/Sources/Lib/LintLokalization.swift
+++ b/Sources/Lib/LintLokalization.swift
@@ -25,7 +25,7 @@ public struct Main: ParsableCommand {
   var benchmarkMode: Bool = false
   
   @Option(help: "Only applicable when `benchmarkMode = true`.")
-  var benchmarkRepatCount: Int = 100
+  var benchmarkRepeatCount: Int = 100
   
   public init() {}
   
@@ -47,7 +47,7 @@ public struct Main: ParsableCommand {
       let linesProcessedCount: Int
     }
     
-    let (time3, output) = try benchmark(repeat: benchmarkMode ? benchmarkRepatCount : 1) { () -> ThreadOutput in
+    let (time3, output) = try benchmark(repeat: benchmarkMode ? benchmarkRepeatCount : 1) { () -> ThreadOutput in
       let semaphore = DispatchSemaphore(value: 0)
       let reporter = reporter.get()
       

--- a/Sources/Lib/LintLokalization.swift
+++ b/Sources/Lib/LintLokalization.swift
@@ -72,8 +72,10 @@ public struct Main: ParsableCommand {
           errorCount += violations.count
         }
         
-        print(linesProcessedCount)
-        return .init(errorCount: errorCount, linesProcessedCount: linesProcessedCount)
+        return .init(
+          errorCount: errorCount,
+          linesProcessedCount: linesProcessedCount
+        )
       }
       
       
@@ -117,7 +119,7 @@ public struct Main: ParsableCommand {
     print(
       [
         "  - Load directory recursively: \(time1)s".cyan.italic,
-        "  - Load localizaition file   : \(time2)s".cyan.italic,
+        "  - Load localization file    : \(time2)s".cyan.italic,
         "  - Parse and validate sources: \(time3)s".cyan.italic,
         "    > Processed \(contents.count) files, \(output.linesProcessedCount) loc".cyan.italic,
         "    > Throughput [files/s]: \(Int(Double(contents.count) / time3))".cyan.italic,


### PR DESCRIPTION
- Some fixes
- Focused on performance improvements by splitting work into multiple threads

---

Following are three plots displaying how the performance and throughput vary when increasing the number of threads.

The experiments were run on the following spec:
```
- MacBook Pro 16"
- Apple M1 Pro
- 32GB memory
```

[Benchmarked project](https://github.com/devMEremenko/XcodeBenchmark)

![Figure_1](https://user-images.githubusercontent.com/15092411/185611199-20faf466-a1c2-41c4-a2c0-09c87c32cb57.png)

![Figure_2](https://user-images.githubusercontent.com/15092411/185611196-11a8fe6b-8f91-4ea6-8842-61b5cc3bc795.png)

![Figure_3](https://user-images.githubusercontent.com/15092411/185611192-9f04c58b-a112-4f9f-818b-968cc0820578.png)

With 1 thread, these are the results:
```
  - Execution time: 0.8597855818271637s
    > Processed 1130 files, 175435 loc
    > Throughput [files/s]: 1314
    > Throughput [lines/s]: 204045
```

and with 8 threads:
```
  - Execution time: 0.2805419683456421s
    > Processed 1130 files, 175435 loc
    > Throughput [files/s]: 4027
    > Throughput [lines/s]: 625343
```